### PR TITLE
AdviceBomb: CoEve scaffolds (specs/runbooks/governance/seeder)

### DIFF
--- a/components/seeder/README.md
+++ b/components/seeder/README.md
@@ -1,0 +1,10 @@
+# Seeder Component (v0 scaffold)
+
+Purpose: continuously enrich registry with probabilistic observations.
+Out of scope: scraping behind auth; storing PII on-chain.
+
+Interfaces:
+- Writes: /api/events (external), with confidence and evidence
+- Reads: /api/identities/resolve for candidate linkage
+
+_TODO_: prototype CLI, config (allow-lists), logging & metrics.

--- a/docs/governance/charter.md
+++ b/docs/governance/charter.md
@@ -1,0 +1,8 @@
+# Governance Charter (v1 stub)
+
+- Steward Council: quorum rules, policy keys (multisig)
+- Parameter changes via public RFC; versioned diffs
+- Emergency powers: scope, expiry, audit trail
+- Sunlight rules: publish admin actions to transparency log
+
+_TODO_: election/appointment, conflict-of-interest, deactivation.

--- a/docs/runbooks/abuse-response.md
+++ b/docs/runbooks/abuse-response.md
@@ -1,0 +1,8 @@
+# Abuse Response Runbook (v1 stub)
+
+- Triggers: anomaly detection, severe negative events, collusion motifs
+- Immediate actions: quarantine lane; limit reach; preserve evidence
+- SLA: MTTQ target; escalation paths; communication templates
+- Appeals: intake → review → decision; reversal logging
+
+_TODO_: severity matrix, roles & paging, playbooks per attack.

--- a/docs/specs/identity-model.md
+++ b/docs/specs/identity-model.md
@@ -1,0 +1,11 @@
+# Identity Model (v1 stub)
+
+- DID methods: did:key, did:web (v1), did:peer (opt)
+- Identity types: human, AI, bot, team, org, nonhuman
+- Keys & rotations: KERI-style event log (planned)
+- AvatarCode: deterministic identicon from DID pubkey
+- Verification tiers: T0..T3 (+contextual PoP)
+- Status lifecycle: active | quarantined | retired
+- Privacy: selective disclosure; PII vault (encrypted)
+
+_TODO_: finalize DID method choices, AvatarCode v1 spec, lifecycle diagrams.

--- a/docs/specs/scoring-model.md
+++ b/docs/specs/scoring-model.md
@@ -1,0 +1,9 @@
+# MeritRank Scoring Model (v1 stub)
+
+- Event taxonomy: merit, scripttag, reptag, external
+- Weights: severity-weighted; negative dominance enforced
+- Decay: half-life per category
+- Confidence: propagate [0..1] from source; attenuate low-confidence
+- Safeguards: velocity caps, per-context ceilings, issuer reputation
+
+_TODO_: constants table, Wilson/Bayesian shrinkage details, examples.

--- a/docs/specs/transparency-log.md
+++ b/docs/specs/transparency-log.md
@@ -1,0 +1,8 @@
+# Transparency Log & Anchoring (v1 stub)
+
+- Append-only Merkle tree (CT-like)
+- Batch anchor roots to public chain (OpenTimestamps/EVM L2)
+- Admin actions logged; signed releases; snapshots/checkpoints
+- No PII on-chain; proofs reference encrypted blobs only
+
+_TODO_: data structures, anchoring cadence, audit workflow.

--- a/notes/design/seeder-pipeline.md
+++ b/notes/design/seeder-pipeline.md
@@ -1,0 +1,9 @@
+# Seeder Pipeline (design notes, v0)
+
+- Fetch: allow-listed sources, robots.txt respect, politeness rate
+- Extract: NER, signature/credential detection (C2PA/PGP/DID)
+- ER: candidate merges with confidence; avoid forced merges
+- Event mapping: tag as external, include provenance + confidence
+- HITL: review queue for low confidence; owner claim flow override
+
+_TODO_: confidence schema, contradiction handling, opt-out mechanics.


### PR DESCRIPTION
Adds initial skeletons:

- docs/specs/{identity-model,scoring-model,transparency-log}.md
- docs/runbooks/abuse-response.md
- docs/governance/charter.md
- notes/design/seeder-pipeline.md
- components/seeder/README.md

These match the v1 proposal and give placeholders for next sprint.